### PR TITLE
Added Various Fixes on Parsing and Added New Data Fields

### DIFF
--- a/simpleadmin/scripts/build_modem_status
+++ b/simpleadmin/scripts/build_modem_status
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-# Run AT+CGMM to get the modem model
-echo -en "AT+CGMM\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/modemmodel.txt
-sleep 2
-
-#  Run AT+CGCONTRDP once then proceed to while loop
-echo -en "AT+CGCONTRDP\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/apn.txt
-sleep 2
-
-# Run AT+QUIMSLOT? to get the current sim slot
-echo -en "AT+QUIMSLOT?\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/simslot.txt
-sleep 2
-
 while true; do
+    # Run AT+CGMM to get the modem model
+    echo -en "AT+CGMM\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/modemmodel.txt
+    sleep 2
+
+    #  Run AT+CGCONTRDP once then proceed to while loop
+    echo -en "AT+CGCONTRDP\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/apn.txt
+    sleep 2
+
+    # Run AT+QUIMSLOT? to get the current sim slot
+    echo -en "AT+QUIMSLOT?\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/simslot.txt
+    sleep 2
+
     # Send request to modem and wait 5 seconds for data
     echo -en "AT+QSPN;+CEREG=2;+CEREG?;+CEREG=0;+C5GREG=2;+C5GREG?;+C5GREG=0;+CSQ;+QENG=\"servingcell\";+QRSRP;+QCAINFO;+QNWPREFCFG=\"mode_pref\";+QTEMP\r\n" \
     | microcom -t 5000 /dev/ttyOUT > /tmp/modemstatus.txt

--- a/simpleadmin/scripts/build_modem_status
+++ b/simpleadmin/scripts/build_modem_status
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+# Run AT+CGMM to get the modem model
+echo -en "AT+CGMM\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/modemmodel.txt
+sleep 2
+
+#  Run AT+CGCONTRDP once then proceed to while loop
+echo -en "AT+CGCONTRDP\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/apn.txt
+sleep 2
+
+# Run AT+QUIMSLOT? to get the current sim slot
+echo -en "AT+QUIMSLOT?\r\n" | microcom -t 1000 /dev/ttyOUT > /tmp/simslot.txt
+sleep 2
+
 while true; do
     # Send request to modem and wait 5 seconds for data
     echo -en "AT+QSPN;+CEREG=2;+CEREG?;+CEREG=0;+C5GREG=2;+C5GREG?;+C5GREG=0;+CSQ;+QENG=\"servingcell\";+QRSRP;+QCAINFO;+QNWPREFCFG=\"mode_pref\";+QTEMP\r\n" \
-    | microcom -t 3000 /dev/ttyOUT > /tmp/modemstatus.txt
+    | microcom -t 5000 /dev/ttyOUT > /tmp/modemstatus.txt
     if [ $? -eq 0 ]
     then
         # Parse

--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -305,6 +305,7 @@ case $RAT in
 			LBAND=$(echo $QENG5 | cut -d, -f11)
 			PC_BAND="NR5G BAND "$LBAND
 			BW=$(echo $QENG5 | cut -d, -f12)
+			nr_bw
 			LBAND="n"$LBAND" (Bandwidth $BW MHz)"
 			RSCP=$(echo $QENG5 | cut -d, -f13)
 			ECIO=$(echo $QENG5 | cut -d, -f14)

--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -36,6 +36,40 @@ nr_bw() {
 	esac
 }
 
+# Function to get the secondary LTE bands
+get_secondary_bands() {
+	# Extract LTE BANDs from SCC lines
+	SCC_BANDS=$(echo "$OX" | grep '+QCAINFO: "SCC"' | grep -o '"LTE BAND [0-9]\+"' | tr -d '"' | sed '1d')
+	
+	# Extract NR5G BANDs from SCC lines
+	NR_BAND=$(echo "$OX" | grep '+QCAINFO: "SCC"' | grep -o '"NR5G BAND [0-9]\+"' | tr -d '"')
+	
+	# Check if both SCC and NR bands are non-empty
+	if [ -n "$SCC_BANDS" ] && [ -n "$NR_BAND" ]; then
+		# Concatenate LTE BANDs with NR5G BANDs
+		SC_BANDS="$SCC_BANDS<br />$NR_BAND"
+	else
+		# Set SC_BANDS to the non-empty variable or empty if both are empty
+		SC_BANDS="${SCC_BANDS}${NR_BAND}"
+	fi
+}
+
+# Get the modem model from /tmp/modemmodel.txt and parse it
+MODEM_MODEL=$(</tmp/modemmodel.txt)
+# Get the model name from the modem model (they either start with RG or RM)
+MODEM_MODEL=$(echo "$MODEM_MODEL" | grep -o "RG[^ ]\+\|RM[^ ]\+")
+
+# Get the APN from /tmp/apn.txt and parse it
+APN=$(</tmp/apn.txt)
+APN=$(echo "$APN" | grep -o '"[^"]*"' | head -n1 | tr -d '"')
+
+# Get the SIM slot from /tmp/simslot.txt and parse it
+# simslot.txt looks like this: +QUIMSLOT: 1
+SIMSLOT=$(</tmp/simslot.txt)
+SIMSLOT=$(echo "$SIMSLOT" | grep -o "[0-9]")
+# Append SIM before the SIM slot number
+SIMSLOT="SIM "$SIMSLOT
+
 # Read File
 OX=$(</tmp/modemstatus.txt)
 
@@ -61,6 +95,8 @@ COPS_MNC="-"
 CID=""
 CID5=""
 RAT=""
+# get MCCMNC and then remove the quotes
+MCCMNC=$(echo $OX | grep -o "+QSPN: \"[^\"]*\",\"[^\"]*\",\"[^\"]*\",[0-9]\+,\"[0-9]\+\"" | cut -d, -f5) | tr -d '"'
 QSPN=$(echo $OX | grep -o '+QSPN: "[^"]*","[^"]*","[^"]*",[^"]*,"[^"]*"' | cut -c 8-)
 PROVIDER=$(echo $QSPN | cut -d, -f1 | tr -d '"')
 PROVIDER_ID=$(echo $QSPN | cut -d, -f5 | tr -d '"')
@@ -76,12 +112,15 @@ else
 	CSQ_PER="-"
 	CSQ_RSSI="-"
 fi
+get_secondary_bands
+# End of QCAINFO 
 NR_NSA=$(echo $OX | grep -o "+QENG:[ ]\?\"NR5G-NSA\",")
 NR_SA=$(echo $OX | grep -o "+QENG: \"SERVINGCELL\",[^,]\+,\"NR5G-SA\",\"[DFT]\{3\}\",")
 if [ -n "$NR_NSA" ]; then
 	QENG=",,"$(echo $OX" " | grep -o "+QENG: \"LTE\".\+\"NR5G-NSA\"," | tr " " ",")
 	if [ -z "$QENG5" ]; then
-		QENG5=$(echo $OX | grep -o "+QENG:[ ]\?\"NR5G-NSA\",[0-9]\{3\},[0-9]\{2,3\},[0-9]\{1,5\},-[0-9]\{2,3\},[-0-9]\{1,3\},-[0-9]\{2,3\},[0-9]\{1,6\},[0-9]\{1,3\}")
+		# Fixed an issue where the last 2 digits were not included in the regex
+		QENG5=$(echo $OX | grep -o "+QENG:[ ]\?\"NR5G-NSA\",[0-9]\{3\},[0-9]\{2,3\},[0-9]\{1,5\},-[0-9]\{2,3\},[-0-9]\{1,3\},-[0-9]\{2,3\},[0-9]\{1,6\},[0-9]\{1,3\},[0-9]\{1,3\},[0-9]\{1,3\}")
 		if [ -n "$QENG5" ]; then
 			QENG5=$QENG5",,"
 		fi
@@ -109,6 +148,7 @@ if [ -n "$QTEMP" ]; then
 	CTEMP=$(echo $QTEMP | grep -o "[0-9]\{1,3\}")$(printf "\xc2\xb0")"C"
 fi
 RAT=$(echo $QENG | cut -d, -f4 | grep -o "[-A-Z5]\{3,7\}")
+
 
 rm -f /tmp/modnetwork
 case $RAT in
@@ -146,6 +186,7 @@ case $RAT in
 			BWU="unknown"
 		fi
 		if [ -n "$LBAND" ]; then
+			PC_BAND="LTE BAND "$LBAND
 			LBAND="B"$LBAND" (Bandwidth $BWD MHz Down | $BWU MHz Up)"
 		fi
 		RSRP=$(echo $QENG | cut -d, -f15 | grep -o "[0-9]\{1,3\}")
@@ -181,7 +222,7 @@ case $RAT in
 				PCI=$(echo $QENG5 | cut -d, -f4)
 				SCHV=$(echo $QENG5 | cut -d, -f8)
 				SLBV=$(echo $QENG5 | cut -d, -f9) # Now correctly captures the NR band
-				BW=$(echo $QENG5 | cut -d, -f10 | grep -o "[0-9]\{1,3\}")
+				BW=$(echo $QENG5 | cut -d, -f10) # Now gets the correct BW
 				if [ -n "$SLBV" ]; then
 					LBAND=$LBAND"<br />n"$SLBV
 					if [ -n "$BW" ]; then
@@ -194,7 +235,8 @@ case $RAT in
 						CHANNEL=$CHANNEL", -"
 					fi
 				else
-					LBAND=$LBAND"<br />nxx (unknown NR5G band)"
+					# removed the (unknown NR5G BAND) and replaced with No NR5G Band to avoid confusion
+					LBAND=$LBAND"<br />No NR5G Band Detected"
 					CHANNEL=$CHANNEL", -"
 				fi
 				RSCP=$RSCP" dBm<br />"$(echo $QENG5 | cut -d, -f5)
@@ -261,6 +303,7 @@ case $RAT in
 			PCI=$(echo $QENG5 | cut -d, -f8)
 			CHANNEL=$(echo $QENG5 | cut -d, -f10)
 			LBAND=$(echo $QENG5 | cut -d, -f11)
+			PC_BAND="NR5G BAND "$LBAND
 			BW=$(echo $QENG5 | cut -d, -f12)
 			LBAND="n"$LBAND" (Bandwidth $BW MHz)"
 			RSCP=$(echo $QENG5 | cut -d, -f13)
@@ -429,12 +472,11 @@ if [ -z "$LAC" ]; then
 	RNC="-"
 fi
 
-
 LUPDATE=$(date +%s)
 rm -fR /tmp/signal.txt
 MODEZ=$(echo $MODE | tr -d '"')
 {
-    echo 'PROVIDER="'"$PROVIDER"'"'
+	echo 'PROVIDER="'"$PROVIDER"'"'
 	echo 'CSQ="'"$CSQ"'"'
 	echo 'CSQ_PER="'"$CSQ_PER"'"'
 	echo 'CSQ_RSSI="'"$CSQ_RSSI"'"'
@@ -447,6 +489,11 @@ MODEZ=$(echo $MODE | tr -d '"')
 	echo 'NETMODE="'"$NETMODE"'"'
 	echo 'CHANNEL="'"$CHANNEL"'"'
 	echo 'LBAND="'"$LBAND"'"'
+	echo 'PC_BAND="'"$PC_BAND"'"'
+	echo 'SC_BANDS="'"$SC_BANDS"'"'
+	echo 'APN="'"$APN"'"'
+	echo 'MODEM_MODEL="'"$MODEM_MODEL"'"'
+	echo 'SIMSLOT="'"$SIMSLOT"'"'
 	echo 'PCI="'"$PCI"'"'
 	echo 'TEMP="'"$CTEMP"'"'
 	echo 'SINR="'"$SINR"'"'
@@ -454,6 +501,7 @@ MODEZ=$(echo $MODE | tr -d '"')
 	echo 'COPS="'"$COPS"'"'
 	echo 'COPS_MCC="'"$COPS_MCC"'"'
 	echo 'COPS_MNC="'"$COPS_MNC"'"'
+	echo 'MCCMNC="'"$MCCMNC"'"'
 	echo 'LAC="'"$LAC"'"'
 	echo 'LAC_NUM="'""'"'
 	echo 'CID="'"$CID"'"'

--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -52,6 +52,9 @@ get_secondary_bands() {
 		# Set SC_BANDS to the non-empty variable or empty if both are empty
 		SC_BANDS="${SCC_BANDS}${NR_BAND}"
 	fi
+
+	# Get the PCI value. For example: 264 based on this +QCAINFO: "PCC",1775,75,"LTE BAND 3",1,264,-103,-13,-71,0
+	MAIN_PCI=$(echo "$OX" | grep '+QCAINFO: "PCC"' | grep -o ',[0-9]\{1,5\},' | tr -d ',')
 }
 
 # Get the modem model from /tmp/modemmodel.txt and parse it
@@ -219,7 +222,8 @@ case $RAT in
 			echo "0" > /tmp/modnetwork
 			if [ -n "$QENG5" ]; then
 				QENG5=$QENG5",,"
-				PCI=$(echo $QENG5 | cut -d, -f4)
+				# Append the initial PCI value rather than overwriting it
+				PCI="$PCI, "$(echo $QENG5 | cut -d, -f4)
 				SCHV=$(echo $QENG5 | cut -d, -f8)
 				SLBV=$(echo $QENG5 | cut -d, -f9) # Now correctly captures the NR band
 				BW=$(echo $QENG5 | cut -d, -f10) # Now gets the correct BW

--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -95,9 +95,9 @@ COPS_MNC="-"
 CID=""
 CID5=""
 RAT=""
-# get MCCMNC and then remove the quotes
-MCCMNC=$(echo $OX | grep -o "+QSPN: \"[^\"]*\",\"[^\"]*\",\"[^\"]*\",[0-9]\+,\"[0-9]\+\"" | cut -d, -f5) | tr -d '"'
 QSPN=$(echo $OX | grep -o '+QSPN: "[^"]*","[^"]*","[^"]*",[^"]*,"[^"]*"' | cut -c 8-)
+#  GET MCCMNC from the last field of QSPN
+MCCMNC=$(echo $QSPN | cut -d, -f5 | tr -d '"')
 PROVIDER=$(echo $QSPN | cut -d, -f1 | tr -d '"')
 PROVIDER_ID=$(echo $QSPN | cut -d, -f5 | tr -d '"')
 CSQ=$(echo $OX | grep -o "+CSQ: [0-9]\{1,2\}" | grep -o "[0-9]\{1,2\}")

--- a/simpleadmin/scripts/tojson.sh
+++ b/simpleadmin/scripts/tojson.sh
@@ -2,21 +2,32 @@
 # sarav (hello@grity.com)
 # convert key=value to json
 # Created at Gritfy ( Devops Junction )
-#
+# Updated by: dr-dolomite to make it more robust since it was failing on some casess
 
-file_name=$1
-last_line=$(wc -l < $file_name)
-current_line=0
+file_name="$1"
 
 echo "{"
-while read line
-do
-  current_line=$(($current_line + 1))
-  if [[ $current_line -ne $last_line ]]; then
-  [ -z "$line" ] && continue
-     echo $line|awk -F'='  '{ print " \""$1"\" : "$2","}'|grep -iv '\"#'
-  else
-    echo $line|awk -F'='  '{ print " \""$1"\" : "$2""}'|grep -iv '\"#'
-  fi
-done < $file_name
+last_line=$(wc -l < "$file_name")
+
+while IFS='=' read -r key value || [[ -n "$key" ]]; do
+    # Skip empty lines and comments
+    if [[ -z "$key" || "$key" == \#* ]]; then
+        continue
+    fi
+
+    # Trim leading and trailing whitespace from key and value
+    key=$(echo "$key" | awk '{$1=$1};1')
+    value=$(echo "$value" | awk '{$1=$1};1')
+
+    # Print key-value pair in JSON format without surrounding double quotes on value
+    printf ' "%s" : %s' "$key" "$value"
+
+    # Check if not the last line, add comma
+    if [ $((++current_line)) -lt "$last_line" ]; then
+        printf ','
+    fi
+
+    printf '\n'
+done < "$file_name"
+
 echo "}"

--- a/simpleadmin/www/atcommander.html
+++ b/simpleadmin/www/atcommander.html
@@ -19,7 +19,7 @@
         <div class="container">
             <div class="navbar-brand">
                 <a class="navbar-item brand-text" href="/">
-                    Quectel RM5xxx Simple Admin
+                    Quectel Simple Admin
                 </a>
                 <a role="button" class="navbar-burger burger" @click="isOpen = !isOpen">
                     <span aria-hidden="true"></span>
@@ -143,8 +143,6 @@
 								<li>AT+QMAP="DHCPV4DNS","disable" (disable the onboard DNS proxy; recommended for IPPT)</li>
 								<li>AT+QMAP="MPDN_rule",0,1,0,1,1,"FF:FF:FF:FF:FF:FF" (Turn on IP Passthrough for Ethernet)</li>
 								<li>AT+QMAP="MPDN_rule",0 (turn off IPPT/clear MPDN rule 0; Remember to run AT+QMAPWAC=1 and reboot after)</li>
-								<li>AT+GSN (Show current IMEI)</li>
-								
                             </ul>
                         </div>
                     </div>

--- a/simpleadmin/www/index.html
+++ b/simpleadmin/www/index.html
@@ -204,7 +204,7 @@
                           <td x-text="csqData.CHANNEL"></td>
                         </tr>
                         <tr>
-                          <th>PCI</th>
+                          <th>4G PCI, 5G PCI</th>
                           <td x-text="csqData.PCI"></td>
                         </tr>
                       </tbody>

--- a/simpleadmin/www/index.html
+++ b/simpleadmin/www/index.html
@@ -17,9 +17,7 @@
     <nav class="navbar is-black" x-data="{ isOpen: false }">
       <div class="container">
         <div class="navbar-brand">
-          <a class="navbar-item brand-text" href="/">
-            Quectel Simple Admin
-          </a>
+          <a class="navbar-item brand-text" href="/"> Quectel Simple Admin </a>
           <a
             role="button"
             class="navbar-burger burger"
@@ -65,22 +63,22 @@
             <div class="tile is-ancestor has-text-centered">
               <div class="tile is-parent">
                 <article class="tile is-child box">
-                  <!-- relocated signal strength here -->
-                  <p class="title" x-text="csqData.MODE"></p>
-                  <p class="subtitle">Network</p>
+                  <!-- added APN -->
+                  <p class="title" x-text="csqData.APN"></p>
+                  <p class="subtitle">Current APN</p>
                   <p
                     class="title"
                     style="margin-top: 1rem"
-                    x-text="csqData.CSQ_PER"
+                    x-html="csqData.SIMSLOT"
                   ></p>
-                  <p class="subtitle">Signal Strength</p>
+                  <p class="subtitle">Current SIM</p>
                 </article>
               </div>
               <div class="tile is-parent">
                 <article class="tile is-child box">
                   <!-- added APN -->
-                  <p class="title" x-text="csqData.APN"></p>
-                  <p class="subtitle">Current APN</p>
+                  <p class="title" x-text="csqData.MODE"></p>
+                  <p class="subtitle">Network</p>
                   <p
                     class="title"
                     x-text="csqData.PC_BAND"
@@ -98,8 +96,8 @@
               </div>
               <div class="tile is-parent">
                 <article class="tile is-child box">
-                  <p class="title" x-html="csqData.SIMSLOT"></p>
-                  <p class="subtitle">Current SIM</p>
+                  <p class="title" x-text="csqData.CSQ_PER"></p>
+                  <p class="subtitle">Signal Strength</p>
                   <p
                     class="title"
                     x-text="csqData.TEMP"
@@ -204,7 +202,7 @@
                           <td x-text="csqData.CHANNEL"></td>
                         </tr>
                         <tr>
-                          <th>4G PCI, 5G PCI</th>
+                          <th>PCI</th>
                           <td x-text="csqData.PCI"></td>
                         </tr>
                       </tbody>

--- a/simpleadmin/www/index.html
+++ b/simpleadmin/www/index.html
@@ -1,233 +1,246 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- change to a much simpler tab title -->
+    <title>Simple Admin</title>
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>RM5xxx Connection Info</title>
-    
     <script src="/js/alpinejs.min.js" defer></script>
-    <link rel="stylesheet" href="/css/bulma.css">
-    <link rel="stylesheet" type="text/css" href="/css/admin.css">
-</head>
+    <link rel="stylesheet" href="/css/bulma.css" />
+    <link rel="stylesheet" type="text/css" href="/css/admin.css" />
+  </head>
 
-<body>
-
+  <body>
     <!-- START NAV -->
     <nav class="navbar is-black" x-data="{ isOpen: false }">
-        <div class="container">
-            <div class="navbar-brand">
-                <a class="navbar-item brand-text" href="/">
-                    Quectel RM5xxx Simple Admin
-                </a>
-                <a role="button" class="navbar-burger burger" @click="isOpen = !isOpen">
-                    <span aria-hidden="true"></span>
-                    <span aria-hidden="true"></span>
-                    <span aria-hidden="true"></span>
-                </a>
-            </div>
-            <div id="navMenu" class="navbar-menu" :class="isOpen ? 'is-active' : ''">
-                <div class="navbar-start">
-                    <a class="navbar-item" href="/">
-                        Connection Info
-                    </a>
-                    <a class="navbar-item" href="/atcommander.html">
-                        AT Commands
-                    </a>
-                    <a class="navbar-item" href="/ttl.html">
-                        TTL Changer
-                    </a>
-                </div>
-
-            </div>
+      <div class="container">
+        <div class="navbar-brand">
+          <a class="navbar-item brand-text" href="/">
+            Quectel Simple Admin
+          </a>
+          <a
+            role="button"
+            class="navbar-burger burger"
+            @click="isOpen = !isOpen"
+          >
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+          </a>
         </div>
+        <div
+          id="navMenu"
+          class="navbar-menu"
+          :class="isOpen ? 'is-active' : ''"
+        >
+          <div class="navbar-start">
+            <a class="navbar-item" href="/"> Connection Info </a>
+            <a class="navbar-item" href="/atcommander.html"> AT Commands </a>
+            <a class="navbar-item" href="/ttl.html"> TTL Changer </a>
+          </div>
+        </div>
+      </div>
     </nav>
     <!-- END NAV -->
     <div class="container">
-        <div class="columns">
-            <div class="column is-12" x-data="getSignalData()" x-init="init()">
-                <section class="hero is-info welcome is-small">
-                    <div class="hero-body">
-                        <div class="container">
-                            <h1 class="title">
-                                Quectel RMxxx Connection Info
-                            </h1>
-                            <h2 class="subtitle">
-                                Data Updated: <span x-text="lastUpdate"></span>
-                            </h2>
-                        </div>
-                    </div>
-                </section>
-                <section class="info-tiles">
-                    <div class="tile is-ancestor has-text-centered">
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
-                                <p class="title" x-text="csqData.MODE"></p>
-                                <p class="subtitle">Network</p>
-                            </article>
-                        </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
-                                <p class="title" x-text="csqData.CSQ_PER"></p>
-                                <p class="subtitle">Signal Strength</p>
-                            </article>
-                        </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
-                                <p class="title" x-text="csqData.TEMP"></p>
-                                <p class="subtitle">Modem Temperature</p>
-                            </article>
-                        </div>
-                        <div class="tile is-parent">
-                            <article class="tile is-child box">
-                                <p class="title" x-html="csqData.LBAND"></p>
-                                <p class="subtitle">Band</p>
-                            </article>
-                        </div>
-                    </div>
-                </section>
-                <div class="columns">
-                    <div class="column is-6">
-                        <div class="card events-card">
-                            <header class="card-header">
-                                <p class="card-header-title">
-                                    Signal Information
-                                </p>
-                            </header>
-                            <div class="card-table">
-                                <div class="content">
-                                    <table class="table is-fullwidth is-striped">
-                                        <tbody>
-                                            <tr>
-                                                <th>Provider</th>
-                                                <td x-text="csqData.PROVIDER">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>CSQ</th>
-                                                <td x-text="csqData.CSQ">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Signal Strength</th>
-                                                <td x-text="csqData.CSQ_PER">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>RSSI</th>
-                                                <td x-text="csqData.CSQ_RSSI">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>ECIO<sup>3G</sup>/RSRQ<sup>4G</sup>/SS_RSRQ<sup>5G</sup></th>
-                                                <td x-html="csqData.ECIO">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>RSCP<sup>3G</sup>/RSRP<sup>4G</sup>/SS_RSRP<sup>5G</sup></th>
-                                                <td x-html="csqData.RSCP">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>SINR</th>
-                                                <td x-html="csqData.SINR">
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="column is-6">
-                        <div class="card events-card">
-                            <header class="card-header">
-                                <p class="card-header-title">
-                                    Cell Information
-                                </p>
-                            </header>
-                            <div class="card-table">
-                                <div class="content">
-                                    <table class="table is-fullwidth is-striped">
-                                        <tbody>
-                                            <tr>
-                                                <th>MCC MNC</th>
-                                                <td>
-                                                    <span x-text="csqData.COPS_MCC"></span>
-                                                    /
-                                                    <span x-text="csqData.COPS_MNC"></span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>RNC<sup>3G</sup>/eNB ID<sup>4G/5G</sup></th>
-                                                <td>
-                                                    <span x-text="csqData.RNC"></span>
-                                                    <span x-text="csqData.RNC_NUM"></span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Lag<sup>3G</sup>/TAC<sup>4G/5G</sup></th>
-                                                <td>
-                                                    <span x-text="csqData.LAC"></span>
-                                                    <span x-text="csqData.LAC_NUM"></span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Cell ID</th>
-                                                <td x-text="csqData.CID">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Band</th>
-                                                <td x-html="csqData.LBAND">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>Channel</th>
-                                                <td x-text="csqData.CHANNEL">
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th>PCI</th>
-                                                <td x-text="csqData.PCI">
-                                                </td>
-                                            </tr>
-
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+      <div class="columns">
+        <div class="column is-12" x-data="getSignalData()" x-init="init()">
+          <section class="hero is-info welcome is-small">
+            <div class="hero-body">
+              <div class="container">
+                <!-- Fetches the correct Model Name -->
+                <h1 class="title">
+                  Quectel <span x-text="csqData.MODEM_MODEL"></span> Connection
+                  Info
+                </h1>
+                <h2 class="subtitle">
+                  Data Updated: <span x-text="lastUpdate"></span>
+                </h2>
+              </div>
             </div>
+          </section>
+          <section class="info-tiles">
+            <div class="tile is-ancestor has-text-centered">
+              <div class="tile is-parent">
+                <article class="tile is-child box">
+                  <!-- relocated signal strength here -->
+                  <p class="title" x-text="csqData.MODE"></p>
+                  <p class="subtitle">Network</p>
+                  <p
+                    class="title"
+                    style="margin-top: 1rem"
+                    x-text="csqData.CSQ_PER"
+                  ></p>
+                  <p class="subtitle">Signal Strength</p>
+                </article>
+              </div>
+              <div class="tile is-parent">
+                <article class="tile is-child box">
+                  <!-- added APN -->
+                  <p class="title" x-text="csqData.APN"></p>
+                  <p class="subtitle">Current APN</p>
+                  <p
+                    class="title"
+                    x-text="csqData.PC_BAND"
+                    style="margin-top: 1rem"
+                  ></p>
+                  <p class="subtitle">Primary Band</p>
+                </article>
+              </div>
+              <!-- added primary band and secondary bands value -->
+              <div class="tile is-parent">
+                <article class="tile is-child box">
+                  <p class="title" x-html="csqData.SC_BANDS"></p>
+                  <p class="subtitle">Aggregated Bands</p>
+                </article>
+              </div>
+              <div class="tile is-parent">
+                <article class="tile is-child box">
+                  <p class="title" x-html="csqData.SIMSLOT"></p>
+                  <p class="subtitle">Current SIM</p>
+                  <p
+                    class="title"
+                    x-text="csqData.TEMP"
+                    style="margin-top: 1rem"
+                  ></p>
+                  <p class="subtitle">Modem Temperature</p>
+                </article>
+              </div>
+            </div>
+          </section>
+          <div class="columns">
+            <div class="column is-6">
+              <div class="card events-card">
+                <header class="card-header">
+                  <p class="card-header-title">Signal Information</p>
+                </header>
+                <div class="card-table">
+                  <div class="content">
+                    <table class="table is-fullwidth is-striped">
+                      <tbody>
+                        <tr>
+                          <th>Provider</th>
+                          <td x-text="csqData.PROVIDER"></td>
+                        </tr>
+                        <tr>
+                          <th>CSQ</th>
+                          <td x-text="csqData.CSQ"></td>
+                        </tr>
+                        <tr>
+                          <th>Signal Strength</th>
+                          <td x-text="csqData.CSQ_PER"></td>
+                        </tr>
+                        <tr>
+                          <th>RSSI</th>
+                          <td x-text="csqData.CSQ_RSSI"></td>
+                        </tr>
+                        <tr>
+                          <th>
+                            ECIO<sup>3G</sup>/RSRQ<sup>4G</sup>/SS_RSRQ<sup
+                              >5G</sup
+                            >
+                          </th>
+                          <td x-html="csqData.ECIO"></td>
+                        </tr>
+                        <tr>
+                          <th>
+                            RSCP<sup>3G</sup>/RSRP<sup>4G</sup>/SS_RSRP<sup
+                              >5G</sup
+                            >
+                          </th>
+                          <td x-html="csqData.RSCP"></td>
+                        </tr>
+                        <tr>
+                          <th>SINR</th>
+                          <td x-html="csqData.SINR"></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="column is-6">
+              <div class="card events-card">
+                <header class="card-header">
+                  <p class="card-header-title">Cell Information</p>
+                </header>
+                <div class="card-table">
+                  <div class="content">
+                    <table class="table is-fullwidth is-striped">
+                      <tbody>
+                        <tr>
+                          <th>MCC MNC</th>
+                          <td>
+                            <span x-text="csqData.MCCMNC"></span>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>RNC<sup>3G</sup>/eNB ID<sup>4G/5G</sup></th>
+                          <td>
+                            <span x-text="csqData.RNC"></span>
+                            <span x-text="csqData.RNC_NUM"></span>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>Lag<sup>3G</sup>/TAC<sup>4G/5G</sup></th>
+                          <td>
+                            <span x-text="csqData.LAC"></span>
+                            <span x-text="csqData.LAC_NUM"></span>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th>Cell ID</th>
+                          <td x-text="csqData.CID"></td>
+                        </tr>
+                        <tr>
+                          <th>Band</th>
+                          <td x-html="csqData.LBAND"></td>
+                        </tr>
+                        <tr>
+                          <th>Channel</th>
+                          <td x-text="csqData.CHANNEL"></td>
+                        </tr>
+                        <tr>
+                          <th>PCI</th>
+                          <td x-text="csqData.PCI"></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
 
     <script>
-        function getSignalData() {
-            return {
-                csqData: {},
-                lastUpdate: new Date().toLocaleString(),
-                getcsq() {
-                    fetch('/cgi-bin/get_csq')
-                        .then((res) => res.json())
-                        .then((data) => {
-                            this.csqData = data;
-                            this.lastUpdate = new Date(data.LASTUPDATE * 1000).toLocaleString();
-                        });
-                },
-                init() {
-                    this.getcsq();
-                    setInterval(() => {
-                        this.getcsq();
-                    }, 30000);
-                }
-
-            }
-        }
+      function getSignalData() {
+        return {
+          csqData: {},
+          lastUpdate: new Date().toLocaleString(),
+          getcsq() {
+            fetch("/cgi-bin/get_csq")
+              .then((res) => res.json())
+              .then((data) => {
+                this.csqData = data;
+                this.lastUpdate = new Date(
+                  data.LASTUPDATE * 1000
+                ).toLocaleString();
+              });
+          },
+          init() {
+            this.getcsq();
+            setInterval(() => {
+              this.getcsq();
+            }, 30000);
+          },
+        };
+      }
     </script>
-</body>
-
+  </body>
 </html>

--- a/simpleadmin/www/ttl.html
+++ b/simpleadmin/www/ttl.html
@@ -19,7 +19,7 @@
         <div class="container">
             <div class="navbar-brand">
                 <a class="navbar-item brand-text" href="/">
-                    Quectel RM5xxx Simple Admin
+                    Quectel Simple Admin
                 </a>
                 <a role="button" class="navbar-burger burger" @click="isOpen = !isOpen">
                     <span aria-hidden="true"></span>

--- a/simpleadmin/www/ttl.html
+++ b/simpleadmin/www/ttl.html
@@ -103,8 +103,6 @@
         </div>
 
     </div>
-    </div>
-
     <script>
 
         function ttlCommands() {
@@ -132,3 +130,4 @@
         }
     </script>
 </body>
+</html>


### PR DESCRIPTION
Here was what I changed / updated on my fork:

Fixed Band Field not showing the bandwidth of NR Band due to incorrect regex for
Fixed MNCMCC not showing
Fixed tojson script to more robustly parse the data coming from signal.txt
Fixed index.html unpair div tag and unclosed html tag
Fixed Bandwidth value for NR5G SA bands

Added CGCONTRDP, CGMM, QUIMSLOT, and QCAINFO to build_modem_status to query the APN, Model Name, and current Sim Slot.
Added parser for MCCMNC, APN, Model Name, Sim Slot, and QCANFO to show the needed data
Added APN, Primary Band, Aggregated Bands, and Current SIM data fields on index.html
Added dynamic value for model name in "Quectel RMxxx Connection Info"

Changed build_modem_status wait time to 5 seconds according to the initial comment
Changed Navbar titles to Quectel Simpleadmin
Changed Tab title to Simple Admin

![image](https://github.com/iamromulan/quectel-rgmii-toolkit/assets/73575327/18a47a12-7687-4e37-9002-5a9bae155bb5)

![Screenshot (103)](https://github.com/iamromulan/quectel-rgmii-toolkit/assets/73575327/2b45eb47-9935-45a9-a96b-1c5d2fcb0159)
