### PR TITLE
Fixed SA band aggregation

### DIFF
--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -42,7 +42,7 @@ get_secondary_bands() {
 	SCC_BANDS=$(echo "$OX" | grep '+QCAINFO: "SCC"' | grep -o '"LTE BAND [0-9]\+"' | tr -d '"' | sed '1d')
 	
 	# Extract NR5G BANDs from SCC lines
-	NR_BAND=$(echo "$OX" | grep '+QCAINFO: "SCC"' | grep -o '"NR5G BAND [0-9]\+"' | tr -d '"')
+	NR_BAND=$(echo "$OX" | grep '+QCAINFO: "SCC"' | grep -o '"NR5G BAND [0-9]\+"' | tr -d '"' | sed '1d')
 	
 	# Check if both SCC and NR bands are non-empty
 	if [ -n "$SCC_BANDS" ] && [ -n "$NR_BAND" ]; then


### PR DESCRIPTION
Parsing failed with more than one band used in SA mode. This does not allow for more than 3 bands in NSA or 2 bands in SA. Relevant for better towers and better rm521 modems.