### PR TITLE
Fixed APN and SCC parsing

### DIFF
--- a/simpleadmin/scripts/modemstatus_parse.sh
+++ b/simpleadmin/scripts/modemstatus_parse.sh
@@ -62,8 +62,7 @@ MODEM_MODEL=$(</tmp/modemmodel.txt)
 MODEM_MODEL=$(echo "$MODEM_MODEL" | grep -o "RG[^ ]\+\|RM[^ ]\+")
 
 # Get the APN from /tmp/apn.txt and parse it
-APN=$(</tmp/apn.txt)
-APN=$(echo "$APN" | grep -o '"[^"]*"' | head -n1 | tr -d '"')
+APN=$(grep "^+CGCONTRDP" /tmp/apn.txt | awk -F',' '{gsub(/"/, "", $3); print $3}')
 
 # Get the SIM slot from /tmp/simslot.txt and parse it
 # simslot.txt looks like this: +QUIMSLOT: 1

--- a/simpleadmin/scripts/tojson.sh
+++ b/simpleadmin/scripts/tojson.sh
@@ -8,6 +8,7 @@ file_name="$1"
 
 echo "{"
 last_line=$(wc -l < "$file_name")
+first_line=true
 
 while IFS='=' read -r key value || [[ -n "$key" ]]; do
     # Skip empty lines and comments
@@ -26,13 +27,20 @@ while IFS='=' read -r key value || [[ -n "$key" ]]; do
         value="\"$value\""
     fi
 
-    # Print key-value pair in JSON format without surrounding double quotes on value
-    printf ' "%s" : %s' "$key" "$value"
+    # Check if value is empty, if so, skip printing this key-value pair
+    if [[ -z "$value" ]]; then
+        continue
+    fi
 
-    # Check if not the last line, add comma
-    if [ $((++current_line)) -lt "$last_line" ]; then
+    # Print comma before each pair except for the first one
+    if $first_line; then
+        first_line=false
+    else
         printf ','
     fi
+
+    # Print key-value pair in JSON format without surrounding double quotes on value
+    printf ' "%s" : %s' "$key" "$value"
 
     printf '\n'
 done < "$file_name"


### PR DESCRIPTION
Applied fixes:
- APN parse now fetches the +CGCONTRDP line and gets the third value despite having double quotes or not.
- The get_secondary_band function was now being called conditionally. If the network is NR5G SA, apply the first line deletion to remove the NR5G PCC band. 
- Changed NSA Network mode to simply "NR5G NSA"
