### PR TITLE
Bind simpleadmin and ttyd only to the 192.168.225.1 address

### DIFF
--- a/simpleadmin/systemd/simpleadmin_httpd.service
+++ b/simpleadmin/systemd/simpleadmin_httpd.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/httpd -f -h /usrdata/simpleadmin/www -p 8080
+ExecStart=/usr/sbin/httpd -f -h /usrdata/simpleadmin/www -p 192.168.225.1:8080
 ExecStop=/bin/kill -WINCH ${MAINPID}
 
 [Install]

--- a/ttyd/systemd/ttyd.service
+++ b/ttyd/systemd/ttyd.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sleep 5
-ExecStart=/usrdata/ttyd/ttyd -p 443 -t 'theme={"foreground":"white","background":"black"}' -t fontSize=25 --writable /usrdata/ttyd/scripts/ttyd.bash
+ExecStart=/usrdata/ttyd/ttyd -p 443 -i 192.168.225.1 -t 'theme={"foreground":"white","background":"black"}' -t fontSize=25 --writable /usrdata/ttyd/scripts/ttyd.bash
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
I am not sure if this is the best way or not. I think it's the most secure and won't likely required iptables rules I don't think. 