### PR TITLE
Hot fix and band locking improvement and 502 support

### DIFF
--- a/simpleadmin/www/index.html
+++ b/simpleadmin/www/index.html
@@ -682,10 +682,17 @@
 
                   // --- Temperature ---
                   // find this example value from lines "+QTEMP:"cpuss-0-usr","50"
-                  this.temperature = lines
-                    .find((line) => line.includes('+QTEMP:"cpuss-0-usr"'))
-                    .split(",")[1]
-                    .replace(/"/g, "");
+                  try {
+                    this.temperature = lines
+                      .find((line) => line.includes('+QTEMP:"cpuss-0-usr"'))
+                      .split(",")[1]
+                      .replace(/"/g, "");
+                  } catch (error) {
+                    this.temperature = lines
+                      .find((line) => line.includes('+QTEMP:"cpu0-a7-usr"'))
+                      .split(",")[1]
+                      .replace(/"/g, "");
+                  }
 
                   // --- SIM Status ---
                   // find this example value from lines "+QSIMSTAT: 0,1"

--- a/simpleadmin/www/js/parse-settings.js
+++ b/simpleadmin/www/js/parse-settings.js
@@ -16,7 +16,7 @@ function parseCurrentSettings(rawdata) {
 
   try {
     this.apn = lines
-      .find((line) => line.includes("+CGCONTRDP: 1,0"))
+      .find((line) => line.includes("+CGCONTRDP: 1"))
       .split(",")[2]
       .replace(/\"/g, "");
   } catch (error) {
@@ -49,10 +49,22 @@ function parseCurrentSettings(rawdata) {
     .replace(/\"/g, "");
 
   try {
-    this.bands = lines
-      .find((line) => line.includes("+QCAINFO:"))
+    const PCCbands = lines
+      .find((line) => line.includes('+QCAINFO: "PCC"'))
       .split(",")[3]
       .replace(/\"/g, "");
+    
+    // Loop over all QCAINFO: "SCC" lines and get the bands
+    try {
+      const SCCbands = lines
+        .filter((line) => line.includes('+QCAINFO: "SCC"'))
+        .map((line) => line.split(",")[3].replace(/\"/g, ""))
+        .join(", ");
+      this.bands = `${PCCbands}, ${SCCbands}`;
+    } catch (error) {
+      this.bands = PCCbands;
+    }
+    
   } catch (error) {
     this.bands = "Failed fetching bands";
   }

--- a/simpleadmin/www/js/populate-checkbox.js
+++ b/simpleadmin/www/js/populate-checkbox.js
@@ -15,7 +15,7 @@ function populateCheckboxes(lte_band, nsa_nr5g_band, nr5g_band, locked_lte_bands
   checkboxesForm.innerHTML = ""; // Clear existing checkboxes
 
   var bandsArray;
-  if (bands !== null) {
+  if (bands !== null && bands !== "0") {
     bandsArray = bands.split(":");
     bandsArray.forEach(function(band, index) {
       if (index % 5 === 0) {
@@ -68,7 +68,11 @@ function populateCheckboxes(lte_band, nsa_nr5g_band, nr5g_band, locked_lte_bands
       currentRow.appendChild(checkboxDiv);
     });
   } else {
-    // Do nothing
+    // Create a text saying that no bands are available 
+    var noBandsText = document.createElement("p");
+    noBandsText.className = "text-center";
+    noBandsText.innerText = "No supported bands available";
+    checkboxesForm.appendChild(noBandsText);
   }
 
   var currentRow;

--- a/simpleadmin/www/network.html
+++ b/simpleadmin/www/network.html
@@ -132,6 +132,18 @@
                       Reset
                     </button>
                   </div>
+                  <div class="form-check">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      value=""
+                      id="providerBands"
+                      onchange="saveCheckboxState()"
+                    />
+                    <label class="form-check-label" for="providerBands">
+                      Show Provider Supported Bands
+                    </label>
+                  </div>
                 </div>
               </div>
               <div class="card-footer">
@@ -488,15 +500,34 @@
           rawdata: null,
 
           getSupportedBands() {
-            const atcmd = 'AT+QNWPREFCFG="policy_band"';
-            this.sendATcommand(atcmd)
-              .then((rawdata) => {
-                this.rawdata = rawdata;
-                this.parseSupportedBands(rawdata);
-              })
-              .then(() => {
-                this.getLockedBands();
-              });
+            // Load the checkbox state from localStorage
+            const isChecked =
+              localStorage.getItem("providerBandsChecked") === "true";
+            const providerBands = document.getElementById("providerBands");
+            providerBands.checked = isChecked;
+
+            // If the checkbox is checked, then show only the provider bands
+            if (providerBands.checked) {
+              const atcmd = 'AT+QNWPREFCFG="ue_capability_band"';
+              this.sendATcommand(atcmd)
+                .then((rawdata) => {
+                  this.rawdata = rawdata;
+                  this.parseSupportedBands(rawdata);
+                })
+                .then(() => {
+                  this.getLockedBands();
+                });
+            } else {
+              const atcmd = 'AT+QNWPREFCFG="policy_band"';
+              this.sendATcommand(atcmd)
+                .then((rawdata) => {
+                  this.rawdata = rawdata;
+                  this.parseSupportedBands(rawdata);
+                })
+                .then(() => {
+                  this.getLockedBands();
+                });
+            }
           },
 
           parseSupportedBands(rawdata) {
@@ -613,7 +644,6 @@
               'AT+QUIMSLOT?;+CGCONTRDP=1;+QNWLOCK="common/4g";+QNWLOCK="common/5g";+QNWPREFCFG="mode_pref";+QNWPREFCFG="nr5g_disable_mode";+QCAINFO;+CGDCONT?';
 
             this.sendATcommand(atcmd).then((rawdata) => {
-              console.log(rawdata);
               const settings = parseCurrentSettings(rawdata);
               this.sim = settings.sim;
               this.apn = settings.apn;
@@ -622,8 +652,6 @@
               this.prefNetwork = settings.prefNetwork;
               this.nrModeControl = settings.nrModeControl;
               this.bands = settings.bands;
-
-              console.log(settings);
             });
           },
           lockSelectedBands() {
@@ -639,19 +667,16 @@
                 atcmd = `AT+QNWPREFCFG="lte_band",${newCheckedValues.join(
                   ":"
                 )}`;
-                console.log(atcmd);
                 this.sendATcommand(atcmd);
               } else if (selectedMode === "NSA") {
                 atcmd = `AT+QNWPREFCFG="nsa_nr5g_band",${newCheckedValues.join(
                   ":"
                 )}`;
-                console.log(atcmd);
                 this.sendATcommand(atcmd);
               } else if (selectedMode === "SA") {
                 atcmd = `AT+QNWPREFCFG="nr5g_band",${newCheckedValues.join(
                   ":"
                 )}`;
-                console.log(atcmd);
                 this.sendATcommand(atcmd);
               } else {
                 alert("Invalid network mode selected");
@@ -706,8 +731,6 @@
             atSIM = "";
             ATNetwork = "";
             ATNRMode = "";
-
-            console.log(this.newApnIP);
 
             if (newApn !== null) {
               if (this.newApnIP === "1") {
@@ -945,6 +968,32 @@
               checkbox.checked = false;
             });
         });
+
+      // Function for setting the provider bands checkbox and fetching the bands
+      document
+        .getElementById("providerBands")
+        .addEventListener("change", function () {
+          cellLocking().getSupportedBands();
+        });
+
+      document.addEventListener("DOMContentLoaded", (event) => {
+        loadCheckboxState();
+      });
+
+      function saveCheckboxState() {
+        const providerBandsCheckbox = document.getElementById("providerBands");
+        localStorage.setItem(
+          "providerBandsChecked",
+          providerBandsCheckbox.checked
+        );
+      }
+
+      function loadCheckboxState() {
+        const providerBandsCheckbox = document.getElementById("providerBands");
+        const isChecked =
+          localStorage.getItem("providerBandsChecked") === "true";
+        providerBandsCheckbox.checked = isChecked;
+      }
     </script>
     <script src="js/dark-mode.js"></script>
   </body>


### PR DESCRIPTION
Changes:
- Added option to only show network provider bands
- Added "No supported bands available" if no band was available
- Made the checkbox for showing network provider bands persistent

Fixes:
- Fixed APN not being fetched
- Fixed current bands only shows PCC

Added support for 502