### PR TITLE
[BUG FIX] Fix Parsing for the phone number on received SMS

### DIFF
--- a/simpleadmin/www/sms.html
+++ b/simpleadmin/www/sms.html
@@ -220,10 +220,10 @@
           while ((match = cmglRegex.exec(data)) !== null) {
             const index = parseInt(match[1]);
             const senderHex = match[2];
-             // Maximum world wide phone number length is 17, UTF-16BE Hex string comes back at 48+ for US Number, min lenght is 4. 
-             // When 4 digit SMS short code is used the result is a 16 length string (which we then need to check if the sender hex starts with 003 or 002(+))
-             // This check is probably completley unecessary but I have no data on how the modems behave around the world otherwise.
-            const sender = senderHex.length > 15 && (senderHex.startsWith('002B') || senderHex.startsWith('003')) ? this.convertHexToText(senderHex) : senderHex;
+             // Maximum world wide phone number length is 17 (North Korea), UTF-16BE Hex string comes back at 48+ for US Number, min length is 3. 
+             // When 3 digit SMS short code is used the result is a 12 length string (which we then need to check if the sender hex starts with 003 or 002B(+))
+             // This check is probably completley unecessary but I have no data on how the modems behave with different firmware(whether support for CSCS="UCS2" is available).
+            const sender = senderHex.length > 11 && (senderHex.startsWith('002B') || senderHex.startsWith('003')) ? this.convertHexToText(senderHex) : senderHex;
             const dateStr = match[3].replace(/\+\d{2}$/, "");
             const date = this.parseCustomDate(dateStr);
             if (isNaN(date)) {

--- a/simpleadmin/www/sms.html
+++ b/simpleadmin/www/sms.html
@@ -220,7 +220,10 @@
           while ((match = cmglRegex.exec(data)) !== null) {
             const index = parseInt(match[1]);
             const senderHex = match[2];
-            const sender = senderHex.startsWith("003") ? this.convertHexToText(senderHex) : senderHex;
+             // Maximum world wide phone number length is 17, UTF-16BE Hex string comes back at 48+ for US Number, min lenght is 4. 
+             // When 4 digit SMS short code is used the result is a 16 length string (which we then need to check if the sender hex starts with 003 or 002(+))
+             // This check is probably completley unecessary but I have no data on how the modems behave around the world otherwise.
+            const sender = senderHex.length > 15 && (senderHex.startsWith('002B') || senderHex.startsWith('003')) ? this.convertHexToText(senderHex) : senderHex;
             const dateStr = match[3].replace(/\+\d{2}$/, "");
             const date = this.parseCustomDate(dateStr);
             if (isNaN(date)) {


### PR DESCRIPTION
Changed the logic to account for senderHex string length >11; if length is >11 then it is 99% a chance that it is in UCS2 format (UTF16BE). Small chance that the resulted value is length 12+ and actually the phone number, minimum length worldwide is 3 for shortcode sms where the hex string would be 12 in length