### PR TITLE
Update Tailscale to 1.96.4

### DIFF
--- a/simpleupdates/scripts/update_tailscale.sh
+++ b/simpleupdates/scripts/update_tailscale.sh
@@ -95,12 +95,12 @@ install_update_tailscale() {
         mkdir -p "$TAILSCALE_DIR" "$TAILSCALE_SYSD_DIR"
         echo "Downloading binary files..."
         cd /usrdata
-        curl -O https://pkgs.tailscale.com/stable/tailscale_1.92.5_arm.tgz
-        tar -xzf tailscale_1.92.5_arm.tgz
-	rm tailscale_1.92.5_arm.tgz
-        cd /usrdata/tailscale_1.92.5_arm
+        curl -O https://pkgs.tailscale.com/stable/tailscale_1.96.4_arm.tgz
+        tar -xzf tailscale_1.96.4_arm.tgz
+	rm tailscale_1.96.4_arm.tgz
+        cd /usrdata/tailscale_1.96.4_arm
         mv tailscale tailscaled "$TAILSCALE_DIR/"
-        rm -rf /usrdata/tailscale_1.92.5_arm
+        rm -rf /usrdata/tailscale_1.96.4_arm
         echo "Downloading systemd files..."
         cd "$TAILSCALE_SYSD_DIR"
         wget $GITROOT/tailscale/systemd/tailscaled.service


### PR DESCRIPTION
## Summary
- Bump Tailscale from **1.92.5 → 1.96.4** (current latest stable) in `simpleupdates/scripts/update_tailscale.sh`.
- Only the download URL, tarball name, and extract path change (5 lines). Existing installs upgrade in place via `tailscale update`; fresh installs pull the new stable tarball.

## Breaking changes
None that affect this deployment.

Relevant items in the 1.92.5 → 1.96.4 range:
- **v1.96.2** — services auto-advertise on startup (behavioral). Opt-out via `TS_EXPERIMENTAL_SERVICE_AUTO_ADVERTISEMENT=false`. This toolkit doesn't publish Tailscale Services, so no action required.
- **v1.96.2** — Go 1.25 → 1.26 + container-aware GOMAXPROCS. May slightly shift memory/CPU footprint; worth watching given the existing systemd memory limit.
- **v1.96.2** — Linux firewall rules now mark traffic correctly to avoid reverse-path-filter drops (neutral/beneficial).
- **v1.96.4** — ENOSYS fallback fix "on forks of Linux" (actively beneficial for Quectel's embedded kernel).
- MIPS segfault fix in 1.96.4 — not applicable (ARM).

No CLI-flag, config-format, or on-disk state migrations are required. Existing nodes keep their keys.

## Test plan
- [ ] On a fresh modem, run the installer path and verify `tailscale_1.96.4_arm.tgz` downloads and extracts cleanly.
- [ ] On a modem already running 1.92.5, exercise the `tailscale update` upgrade path (uses the `/tmp/cache` + `~/.cache` symlink already added in a952ea64).
- [ ] Confirm `tailscaled` starts under systemd and connects.
- [ ] Confirm memory usage stays within the configured systemd mem limit after the Go 1.26 / GOMAXPROCS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)